### PR TITLE
Add assertions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'application'
     id 'checkstyle'
     id 'com.github.johnrengelman.shadow' version '5.1.0'
+    id("org.openjfx.javafxplugin") version "0.0.13"
 }
 
 repositories {
@@ -46,7 +47,7 @@ test {
 }
 
 application {
-    mainClassName = "catbot.Main"
+    mainClassName = "catbot.Launcher"
 }
 
 shadowJar {

--- a/src/main/java/catbot/commands/MarkCommand.java
+++ b/src/main/java/catbot/commands/MarkCommand.java
@@ -34,6 +34,7 @@ public class MarkCommand extends Command {
 
     @Override
     public void loadCommand(ArrayList<Task> tasks) {
+        assert index >= -1 && index < tasks.size(); // Values set during writing to file shouldn't be out of range
         tasks.get(Math.floorMod(index, tasks.size())).setDone(true); // Using floorMod handles -1 case for last index
     }
 }

--- a/src/main/java/catbot/parser/Parser.java
+++ b/src/main/java/catbot/parser/Parser.java
@@ -3,6 +3,7 @@ package catbot.parser;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.Locale;
+import java.util.Objects;
 
 import catbot.CatBotException;
 import catbot.commands.AddCommand;
@@ -26,19 +27,20 @@ public class Parser {
      * @throws CatBotException if the user input is malformed.
      */
     public static Command parse(String command) throws CatBotException {
-        String[] cmd = command.split(" ", 2);
+        assert !Objects.equals(command, "");
+        String[] commandComponents = command.split(" ", 2);
         String[] temp;
-        switch (cmd[0].toLowerCase(Locale.ROOT)) {
+        switch (commandComponents[0].toLowerCase(Locale.ROOT)) {
         case "todo":
             try {
-                return new AddCommand(cmd[1].strip());
+                return new AddCommand(commandComponents[1].strip());
             } catch (ArrayIndexOutOfBoundsException e) {
                 throw new CatBotException("That's the wrong format!");
             }
 
         case "deadline":
             try {
-                temp = cmd[1].split("/by", 2);
+                temp = commandComponents[1].split("/by", 2);
                 LocalDateTime by = LocalDateTime.parse(temp[1].strip());
                 return new AddCommand(temp[0].strip(), by);
             } catch (DateTimeParseException e) {
@@ -49,7 +51,7 @@ public class Parser {
 
         case "event":
             try {
-                temp = cmd[1].split("/from|/to", 3);
+                temp = commandComponents[1].split("/from|/to", 3);
                 LocalDateTime from = LocalDateTime.parse(temp[1].strip());
                 LocalDateTime to = LocalDateTime.parse(temp[2].strip());
                 return new AddCommand(temp[0].strip(), from, to);
@@ -64,7 +66,7 @@ public class Parser {
 
         case "mark":
             try {
-                int index = Integer.parseInt(cmd[1].strip());
+                int index = Integer.parseInt(commandComponents[1].strip());
                 return new MarkCommand(index - 1, true);
             } catch (NumberFormatException e) {
                 throw new CatBotException(e + " isn't a number!");
@@ -74,7 +76,7 @@ public class Parser {
 
         case "unmark":
             try {
-                int index = Integer.parseInt(cmd[1].strip());
+                int index = Integer.parseInt(commandComponents[1].strip());
                 return new MarkCommand(index - 1, false);
             } catch (NumberFormatException e) {
                 throw new CatBotException(e + " isn't a number!");
@@ -84,7 +86,7 @@ public class Parser {
 
         case "delete":
             try {
-                int index = Integer.parseInt(cmd[1].strip());
+                int index = Integer.parseInt(commandComponents[1].strip());
                 return new DeleteCommand(index - 1);
             } catch (NumberFormatException e) {
                 throw new CatBotException(e + " isn't a number!");
@@ -93,11 +95,11 @@ public class Parser {
             }
 
         case "find":
-            return new FindCommand(cmd[1].strip());
+            return new FindCommand(commandComponents[1].strip());
 
         case "echo":
             try {
-                return new EchoCommand(cmd[1].strip());
+                return new EchoCommand(commandComponents[1].strip());
             } catch (ArrayIndexOutOfBoundsException e) {
                 throw new CatBotException("That's the wrong format!");
             }

--- a/src/main/java/catbot/storage/Storage.java
+++ b/src/main/java/catbot/storage/Storage.java
@@ -47,6 +47,7 @@ public class Storage {
      * @throws CatBotException if there was an error while parsing the save file.
      */
     public ArrayList<Task> load() throws CatBotException {
+        assert saveFile.exists() : saveFile.getPath();
         ArrayList<Task> tasks = new ArrayList<>();
 
         try {
@@ -69,6 +70,7 @@ public class Storage {
      * @param message is the string to append to the save file
      */
     public void writeToSaveFile(String message) throws CatBotException {
+        assert saveFile.exists() : saveFile.getPath();
         try (FileWriter writer = new FileWriter(saveFile, true)) {
             writer.write(message);
         } catch (IOException e) {
@@ -81,6 +83,7 @@ public class Storage {
      * @param tasks is the TaskList to write to disk
      */
     public void saveToFile(TaskList tasks) throws CatBotException {
+        assert saveFile.exists() : saveFile.getPath();
         try (FileWriter writer = new FileWriter(saveFile, false)) {
             for (Task task: tasks) {
                 writer.write(task.toCommand() + "\n");

--- a/src/test/java/catbot/commands/AddCommandTest.java
+++ b/src/test/java/catbot/commands/AddCommandTest.java
@@ -2,15 +2,11 @@ package catbot.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
-import java.io.PrintStream;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -20,10 +16,6 @@ import catbot.tasklist.TaskList;
 import catbot.ui.Ui;
 
 public class AddCommandTest {
-    private static final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
-    private static final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
-    private static final PrintStream originalOut = System.out;
-    private static final PrintStream originalErr = System.err;
     private TaskList tasks = new TaskList(new ArrayList<>());
     private final Ui ui = new Ui();
     private final Storage storage = new Storage("./test/tasklist.txt");
@@ -31,26 +23,11 @@ public class AddCommandTest {
     public AddCommandTest() throws CatBotException {
     }
 
-    // https://stackoverflow.com/questions/1119385/junit-test-for-system-out-println
-    @BeforeAll
-    static void setUpStreams() {
-        System.setOut(new PrintStream(outContent));
-        System.setErr(new PrintStream(errContent));
-    }
-
-    @AfterAll
-    static void restoreStreams() {
-        System.setOut(originalOut);
-        System.setErr(originalErr);
-    }
-
     @BeforeEach
     public void reset() throws IOException {
         tasks = new TaskList(new ArrayList<>());
         boolean temp = new File("./test/tasklist.txt").delete();
         boolean temp2 = new File("./test/tasklist.txt").createNewFile();
-        outContent.reset();
-        errContent.reset();
     }
 
     @Test
@@ -58,13 +35,9 @@ public class AddCommandTest {
         Command testCommand = new AddCommand("This is a test");
         testCommand.execute(tasks, ui, storage);
         assertEquals(1, tasks.size());
-        ui.showNext();
-        assertEquals(
-                "╭─ >^w^< ────────────────────────╮\n"
-                + "│ Added new task!                │\n"
-                + "│     [T][ ] This is a test      │\n"
-                + "│ You have 1 task now.           │\n"
-                + "╰────────────────────────────────╯\n\n", outContent.toString());
+        assertEquals("Added new task!\n"
+                + "    [T][ ] This is a test\n"
+                + "You have 1 task now.", ui.getNextOutput().getText());
     }
 
     @Test
@@ -72,13 +45,9 @@ public class AddCommandTest {
         Command testCommand = new AddCommand("This is a test", LocalDateTime.parse("2023-01-29T20:00"));
         testCommand.execute(tasks, ui, storage);
         assertEquals(1, tasks.size());
-        ui.showNext();
-        assertEquals(
-                "╭─ >^w^< ────────────────────────────────────────────╮\n"
-                + "│ Added new task!                                    │\n"
-                + "│     [D][ ] This is a test by 29 Jan 2023, 8:00 PM  │\n"
-                + "│ You have 1 task now.                               │\n"
-                + "╰────────────────────────────────────────────────────╯\n\n", outContent.toString());
+        assertEquals("Added new task!\n"
+                + "    [D][ ] This is a test by 29 Jan 2023, 8:00 PM\n"
+                + "You have 1 task now.", ui.getNextOutput().getText());
     }
 
     @Test
@@ -87,13 +56,8 @@ public class AddCommandTest {
                 LocalDateTime.parse("2023-01-29T20:00"), LocalDateTime.parse("2023-01-29T20:00"));
         testCommand.execute(tasks, ui, storage);
         assertEquals(1, tasks.size());
-        ui.showNext();
-        assertEquals(
-                "╭─ >^w^< ──────────────────────────────────────────────────────────────────────────╮\n"
-                + "│ Added new task!                                                                  │\n"
-                + "│     [E][ ] This is a test (29 Jan 2023, 8:00 PM – 29 Jan 2023, 8:00 PM)          │\n"
-                + "│ You have 1 task now.                                                             │\n"
-                + "╰──────────────────────────────────────────────────────────────────────────────────╯\n\n",
-                outContent.toString());
+        assertEquals("Added new task!\n"
+                + "    [E][ ] This is a test (29 Jan 2023, 8:00 PM – 29 Jan 2023, 8:00 PM)\n"
+                + "You have 1 task now.", ui.getNextOutput().getText());
     }
 }


### PR DESCRIPTION
CatBot lacks assertions to ensure code reliability. Without assertions, catching potential bugs and errors is time-consuming and error-prone.

Let's add assertions to verify that key assumptions are being met throughout the execution of the program.

This makes errors show up early and loudly so that it is easier to spot the source of the issue.